### PR TITLE
Feat/templated params defaults

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -133,7 +133,7 @@ func runNew(cmd *cobra.Command, args []string) error {
 	interactive := isInteractive() && !newPrintParams && !newPrintHooks && !newDryRun && len(newParams) == 0
 	var resolved map[string]any
 	if interactive && tpl.SpinToml != nil && len(tpl.SpinToml.Params) > 0 {
-		resolved, err = runNewTUI(tpl)
+		resolved, err = runNewTUI(tpl, values)
 	} else {
 		resolved, err = tpl.ResolveForm(values, interactive)
 	}

--- a/cmd/new_tui.go
+++ b/cmd/new_tui.go
@@ -49,17 +49,30 @@ type newTUIModel struct {
 	params []params.Param
 }
 
-func newNewTUIModel(tpl *template.Template) (newTUIModel, error) {
+func newNewTUIModel(tpl *template.Template, values map[string]any) (newTUIModel, error) {
 	m := newTUIModel{tpl: tpl, styles: newTUIStyles(), width: termWidth()}
 	ps, err := params.Parse(tpl.SpinToml.Params)
 	if err != nil {
 		return m, err
 	}
-	params.SetDefaults(ps)
+	params.SetDefaults(ps, values)
+	// Seed builtins (name, project_name) and any other supplied values
+	// onto params whose name matches, so the form opens with them
+	// pre-filled -- matching the non-TTY ResolveForm behaviour. Guard
+	// against empty strings: an empty value must never clobber a
+	// param's own default.
+	for _, p := range ps {
+		if v, ok := values[p.Name()]; ok {
+			if s, ok := v.(string); ok && s == "" {
+				continue
+			}
+			p.Apply(params.FromAny(v))
+		}
+	}
 	m.params = ps
 	var fields []huh.Field
 	for _, p := range ps {
-		fields = append(fields, p.HuhField())
+		fields = append(fields, p.HuhField(values))
 	}
 	m.form = huh.NewForm(huh.NewGroup(fields...)).
 		WithWidth(min(m.width/2, 60)).
@@ -236,8 +249,8 @@ func (m newTUIModel) appBoundaryViewFoot(text string) string {
 	)
 }
 
-func runNewTUI(tpl *template.Template) (map[string]any, error) {
-	m, err := newNewTUIModel(tpl)
+func runNewTUI(tpl *template.Template, values map[string]any) (map[string]any, error) {
+	m, err := newNewTUIModel(tpl, values)
 	if err != nil {
 		return nil, err
 	}
@@ -248,6 +261,15 @@ func runNewTUI(tpl *template.Template) (map[string]any, error) {
 	out := map[string]any{}
 	for _, param := range m.params {
 		out[param.Name()] = template.UnwrapValue(param.Value())
+	}
+	// Copy through any caller-supplied/builtin keys that aren't
+	// backed by a param (e.g. project_name). Mirrors
+	// Template.ResolveForm so the TTY and non-TTY paths produce the
+	// same value map.
+	for k, v := range values {
+		if _, ok := out[k]; !ok {
+			out[k] = v
+		}
 	}
 	return out, nil
 }

--- a/internal/params/bool.go
+++ b/internal/params/bool.go
@@ -17,17 +17,17 @@ func NewBool(name, prompt string, def bool) *BoolParam {
 	return &BoolParam{name: name, prompt: prompt, def: def}
 }
 
-func (p *BoolParam) Name() string   { return p.name }
-func (p *BoolParam) Type() Type     { return TypeBool }
-func (p *BoolParam) Prompt() string { return p.prompt }
-func (p *BoolParam) Default() any   { return p.def }
-func (p *BoolParam) SetDefault()    { p.Apply(Value{Kind: TypeBool, Bool: p.def}) }
-func (p *BoolParam) Apply(v Value)  { p.value = v.Bool }
-func (p *BoolParam) Value() Value   { return Value{Kind: TypeBool, Bool: p.value} }
-func (p *BoolParam) HuhField() huh.Field {
+func (p *BoolParam) Name() string                     { return p.name }
+func (p *BoolParam) Type() Type                       { return TypeBool }
+func (p *BoolParam) Prompt() string                   { return p.prompt }
+func (p *BoolParam) Default() any                     { return p.def }
+func (p *BoolParam) SetDefault(values map[string]any) { p.Apply(Value{Kind: TypeBool, Bool: p.def}) }
+func (p *BoolParam) Apply(v Value)                    { p.value = v.Bool }
+func (p *BoolParam) Value() Value                     { return Value{Kind: TypeBool, Bool: p.value} }
+func (p *BoolParam) HuhField(values map[string]any) huh.Field {
 	return huh.NewConfirm().
 		Key(p.name).
-		Title(orPrompt(p.name, p.prompt)).
+		Title(orPrompt(p.name, renderStr(p.prompt, values))).
 		Affirmative("Yes").
 		Negative("No").
 		Value(&p.value)

--- a/internal/params/form.go
+++ b/internal/params/form.go
@@ -1,6 +1,9 @@
 package params
 
 import (
+	"fmt"
+	"slices"
+
 	"charm.land/huh/v2"
 )
 
@@ -14,7 +17,7 @@ const PageSize = 4
 // grouped PageSize-at-a-time into huh.Groups; each Group becomes
 // one form page the user can step through with Next/Prev. A single
 // page is rendered when len(ps) <= PageSize.
-func Form(ps []Param) *huh.Form {
+func Form(ps []Param, values map[string]any) *huh.Form {
 	if len(ps) == 0 {
 		return huh.NewForm()
 	}
@@ -23,7 +26,7 @@ func Form(ps []Param) *huh.Form {
 		end := min(i+PageSize, len(ps))
 		fields := make([]huh.Field, 0, end-i)
 		for _, p := range ps[i:end] {
-			fields = append(fields, p.HuhField())
+			fields = append(fields, p.HuhField(values))
 		}
 		groups = append(groups, huh.NewGroup(fields...))
 	}
@@ -31,15 +34,61 @@ func Form(ps []Param) *huh.Form {
 }
 
 // Run executes the form on the given params. The form populates each
-// param's value in place.
-func Run(ps []Param) error {
-	return Form(ps).Run()
+// param's value in place. values are the currently known template
+// values, used to render prompts/defaults.
+func Run(ps []Param, values map[string]any) error {
+	return Form(ps, values).Run()
 }
 
 // SetDefaults applies each param's default value to its current value.
-// Useful when running non-interactively.
-func SetDefaults(ps []Param) {
+// Useful when running non-interactively. values are used to render any
+// templated defaults.
+func SetDefaults(ps []Param, values map[string]any) {
 	for _, p := range ps {
-		p.SetDefault()
+		p.SetDefault(values)
 	}
+}
+
+// FromAny converts a raw CLI/default value (string, int, bool,
+// []string, []any) into a params.Value suitable for Param.Apply. The
+// Value's Kind is derived from the Go type; each param's Apply picks
+// the field it cares about, so a string maps cleanly onto text,
+// select, textarea, secret and path params.
+func FromAny(v any) Value {
+	switch x := v.(type) {
+	case string:
+		return Value{Kind: TypeText, String: x}
+	case int:
+		return Value{Kind: TypeNumber, Int: x}
+	case bool:
+		return Value{Kind: TypeBool, Bool: x}
+	case []string:
+		return Value{Kind: TypeMultiSelect, List: x}
+	case []any:
+		out := make([]string, 0, len(x))
+		for _, item := range x {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return Value{Kind: TypeMultiSelect, List: out}
+	}
+	return Value{}
+}
+
+// ValidateDefaults checks resolved param values for consistency in the
+// non-interactive path, where huh's per-field Validate does not run.
+// It enforces that a select param's value is one of its options: a
+// templated default (e.g. `default = "{{ .ed }}"`) or a --param value
+// that resolves outside the option list would otherwise pass through
+// silently and produce a broken scaffold.
+func ValidateDefaults(ps []Param) error {
+	for _, p := range ps {
+		if s, ok := p.(*SelectParam); ok {
+			if s.value != "" && !slices.Contains(s.options, s.value) {
+				return fmt.Errorf("%s must be one of %v, got %q", s.name, s.options, s.value)
+			}
+		}
+	}
+	return nil
 }

--- a/internal/params/multiselect.go
+++ b/internal/params/multiselect.go
@@ -22,7 +22,9 @@ func (p *MultiSelectParam) Name() string   { return p.name }
 func (p *MultiSelectParam) Type() Type     { return TypeMultiSelect }
 func (p *MultiSelectParam) Prompt() string { return p.prompt }
 func (p *MultiSelectParam) Default() any   { return p.def }
-func (p *MultiSelectParam) SetDefault()    { p.Apply(Value{Kind: TypeMultiSelect, List: p.def}) }
+func (p *MultiSelectParam) SetDefault(values map[string]any) {
+	p.Apply(Value{Kind: TypeMultiSelect, List: p.def})
+}
 func (p *MultiSelectParam) Apply(v Value) {
 	if v.List == nil {
 		p.value = []string{}
@@ -32,7 +34,7 @@ func (p *MultiSelectParam) Apply(v Value) {
 }
 func (p *MultiSelectParam) Value() Value { return Value{Kind: TypeMultiSelect, List: p.value} }
 
-func (p *MultiSelectParam) HuhField() huh.Field {
+func (p *MultiSelectParam) HuhField(values map[string]any) huh.Field {
 	opts := make([]huh.Option[string], 0, len(p.options))
 	for _, o := range p.options {
 		opt := huh.NewOption(o, o)
@@ -45,7 +47,7 @@ func (p *MultiSelectParam) HuhField() huh.Field {
 	}
 	return huh.NewMultiSelect[string]().
 		Key(p.name).
-		Title(orPrompt(p.name, p.prompt)).
+		Title(orPrompt(p.name, renderStr(p.prompt, values))).
 		Options(opts...).
 		Value(&p.value)
 }

--- a/internal/params/number.go
+++ b/internal/params/number.go
@@ -32,12 +32,12 @@ func NewNumber(name, prompt string, def int, min, max *int) *NumberParam {
 	}
 }
 
-func (p *NumberParam) Name() string   { return p.name }
-func (p *NumberParam) Type() Type     { return TypeNumber }
-func (p *NumberParam) Prompt() string { return p.prompt }
-func (p *NumberParam) Default() any   { return p.def }
-func (p *NumberParam) SetDefault()    { p.Apply(Value{Kind: TypeNumber, Int: p.def}) }
-func (p *NumberParam) Apply(v Value)  { p.value = v.Int; p.valueStr = fmt.Sprintf("%d", v.Int) }
+func (p *NumberParam) Name() string                     { return p.name }
+func (p *NumberParam) Type() Type                       { return TypeNumber }
+func (p *NumberParam) Prompt() string                   { return p.prompt }
+func (p *NumberParam) Default() any                     { return p.def }
+func (p *NumberParam) SetDefault(values map[string]any) { p.Apply(Value{Kind: TypeNumber, Int: p.def}) }
+func (p *NumberParam) Apply(v Value)                    { p.value = v.Int; p.valueStr = fmt.Sprintf("%d", v.Int) }
 func (p *NumberParam) Value() Value {
 	if p.valueStr != "" {
 		if n, err := strconv.Atoi(p.valueStr); err == nil {
@@ -46,10 +46,10 @@ func (p *NumberParam) Value() Value {
 	}
 	return Value{Kind: TypeNumber, Int: p.value}
 }
-func (p *NumberParam) HuhField() huh.Field {
+func (p *NumberParam) HuhField(values map[string]any) huh.Field {
 	return huh.NewInput().
 		Key(p.name).
-		Title(orPrompt(p.name, p.prompt)).
+		Title(orPrompt(p.name, renderStr(p.prompt, values))).
 		Placeholder(fmt.Sprintf("%d", p.def)).
 		Value(&p.valueStr).
 		Validate(func(s string) error {

--- a/internal/params/param.go
+++ b/internal/params/param.go
@@ -37,12 +37,14 @@ type Param interface {
 	Type() Type
 	Prompt() string
 	Default() any
-	SetDefault()
+	SetDefault(values map[string]any)
 	Apply(v Value)
 	Value() Value
 	// HuhField builds the huh field for this param. The form runner
-	// writes the result back via Apply().
-	HuhField() huh.Field
+	// writes the result back via Apply(). values are the currently
+	// known template values, used to render the param's prompt and
+	// default (e.g. `prompt = "Name for {{ .name }}"`).
+	HuhField(values map[string]any) huh.Field
 	// String returns a one-line summary, used by `spin new --print-params`.
 	String() string
 }

--- a/internal/params/parse_test.go
+++ b/internal/params/parse_test.go
@@ -245,7 +245,7 @@ func TestSetDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	SetDefaults(ps)
+	SetDefaults(ps, map[string]any{})
 
 	want := map[string]Value{
 		"name":  {Kind: TypeText, String: "myapp"},
@@ -280,7 +280,7 @@ func TestSetDefaults_PreservesOrder(t *testing.T) {
 		t.Fatalf("Parse: %v", err)
 	}
 	names := []string{ps[0].Name(), ps[1].Name(), ps[2].Name()}
-	SetDefaults(ps)
+	SetDefaults(ps, map[string]any{})
 	got := []string{ps[0].Name(), ps[1].Name(), ps[2].Name()}
 	if !reflect.DeepEqual(names, got) {
 		t.Errorf("order changed: %v → %v", names, got)
@@ -297,7 +297,7 @@ func TestSetDefaults_PreservesOrder(t *testing.T) {
 // applies the default string via Value().
 func TestSetDefault_Textarea(t *testing.T) {
 	p := NewTextarea("desc", "Description", "a\nb")
-	p.SetDefault()
+	p.SetDefault(map[string]any{})
 	got := p.Value()
 	want := Value{Kind: TypeTextarea, String: "a\nb"}
 	if !reflect.DeepEqual(got, want) {
@@ -309,7 +309,7 @@ func TestSetDefault_Textarea(t *testing.T) {
 // param applies the default []string via Value().
 func TestSetDefault_MultiSelect(t *testing.T) {
 	p := NewMultiSelect("features", "Features", []string{"a", "b"}, []string{"a"})
-	p.SetDefault()
+	p.SetDefault(map[string]any{})
 	got := p.Value()
 	want := Value{Kind: TypeMultiSelect, List: []string{"a"}}
 	if !reflect.DeepEqual(got, want) {
@@ -321,7 +321,7 @@ func TestSetDefault_MultiSelect(t *testing.T) {
 // applies the default string via Value().
 func TestSetDefault_Path(t *testing.T) {
 	p := NewPath("out", "Output", "/tmp")
-	p.SetDefault()
+	p.SetDefault(map[string]any{})
 	got := p.Value()
 	want := Value{Kind: TypePath, Path: "/tmp"}
 	if !reflect.DeepEqual(got, want) {
@@ -334,7 +334,7 @@ func TestSetDefault_Path(t *testing.T) {
 func TestSetDefault_Secret(t *testing.T) {
 	p := NewSecret("key", "API Key")
 	p.def = "sk-test"
-	p.SetDefault()
+	p.SetDefault(map[string]any{})
 	got := p.Value()
 	want := Value{Kind: TypeSecret, String: "sk-test"}
 	if !reflect.DeepEqual(got, want) {
@@ -347,7 +347,7 @@ func BenchmarkSetDefaultText(b *testing.B) {
 	p := NewText("name", "Name", "default")
 	b.ResetTimer()
 	for b.Loop() {
-		p.SetDefault()
+		p.SetDefault(map[string]any{})
 	}
 }
 
@@ -362,7 +362,7 @@ func BenchmarkSetDefaults_Small(b *testing.B) {
 	}
 	b.ResetTimer()
 	for b.Loop() {
-		SetDefaults(ps)
+		SetDefaults(ps, map[string]any{})
 	}
 }
 
@@ -380,7 +380,7 @@ func TestSetDefaults_AllTypes(t *testing.T) {
 		NewSecret("h", "H"),
 	}
 	ps[7].(*SecretParam).def = "shh"
-	SetDefaults(ps)
+	SetDefaults(ps, map[string]any{})
 
 	want := map[string]Value{
 		"a": {Kind: TypeText, String: "txt"},

--- a/internal/params/path.go
+++ b/internal/params/path.go
@@ -28,13 +28,15 @@ func (p *PathParam) Name() string   { return p.name }
 func (p *PathParam) Type() Type     { return TypePath }
 func (p *PathParam) Prompt() string { return p.prompt }
 func (p *PathParam) Default() any   { return p.def }
-func (p *PathParam) SetDefault()    { p.Apply(Value{Kind: TypePath, Path: p.def}) }
-func (p *PathParam) Apply(v Value)  { p.value = v.Path }
-func (p *PathParam) Value() Value   { return Value{Kind: TypePath, Path: p.value} }
-func (p *PathParam) HuhField() huh.Field {
+func (p *PathParam) SetDefault(values map[string]any) {
+	p.Apply(Value{Kind: TypePath, Path: renderStr(p.def, values)})
+}
+func (p *PathParam) Apply(v Value) { p.value = v.Path }
+func (p *PathParam) Value() Value  { return Value{Kind: TypePath, Path: p.value} }
+func (p *PathParam) HuhField(values map[string]any) huh.Field {
 	f := huh.NewFilePicker().
 		Key(p.name).
-		Title(orPrompt(p.name, p.prompt))
+		Title(orPrompt(p.name, renderStr(p.prompt, values)))
 	if p.dir {
 		f = f.FileAllowed(false).DirAllowed(true)
 	} else {

--- a/internal/params/render.go
+++ b/internal/params/render.go
@@ -1,0 +1,125 @@
+package params
+
+import (
+	"bytes"
+	"regexp"
+	"slices"
+	"strings"
+	"text/template"
+	"time"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// FuncMap returns the set of template functions available to both
+// file rendering (template.Render) and prompt/default rendering
+// (renderStr). A template author can therefore use the same helpers
+// (snake_case, kebab, quote, ...) in a param's prompt or default as
+// they would in a .tmpl file. This is the single source of truth for
+// those helpers; template/engine.go delegates to it.
+func FuncMap() template.FuncMap {
+	titleCaser := cases.Title(language.English)
+	return template.FuncMap{
+		// Useful in templates
+		"upper": strings.ToUpper,
+		"lower": strings.ToLower,
+		"title": titleCaser.String,
+		"trim":  strings.TrimSpace,
+		"join":  strings.Join,
+		"default": func(d, v any) any {
+			if v == nil || v == "" {
+				return d
+			}
+			return v
+		},
+		// snake_case: "MyProject" -> "my_project".
+		// Splits on case boundaries and word boundaries, joins
+		// with underscores, lowercases.
+		"snake_case": SnakeCase,
+		// kebab-case: "MyProject" -> "my-project". Go's text/template
+		// requires function names to be valid identifiers, so we use
+		// `kebab` (called as `{{ kebab "X" }}`).
+		"kebab": func(s string) string {
+			return strings.ReplaceAll(SnakeCase(s), "_", "-")
+		},
+		// quote: shell-escapes s for use inside a `[[post]] run = "..."`.
+		// Uses single-quote wrapping with the standard "'='"'" trick
+		// so embedded single quotes are escaped correctly.
+		"quote": ShellQuote,
+		// now: current time, formatted. No-arg -> RFC3339. With a
+		// layout string (e.g. "2006") -> that layout.
+		"now": func(layout string) string {
+			if layout == "" {
+				layout = time.RFC3339
+			}
+			return time.Now().UTC().Format(layout)
+		},
+		// contains: substring check. Useful in templates that want
+		// to gate on a value (e.g. `{{ if contains .tags "rust" }}`).
+		"contains": strings.Contains,
+		// has: report whether a []string contains a value. Used by
+		// [[include]] rules and conditional templates.
+		"has": slices.Contains[[]string, string],
+		// not_has: inverse of has.
+		"not_has": func(list []string, item string) bool {
+			return !slices.Contains(list, item)
+		},
+		// one_of: report whether a value equals any of the given strings.
+		"one_of": func(v string, items ...string) bool {
+			return slices.Contains(items, v)
+		},
+	}
+}
+
+var nonWordSplitter = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
+// SnakeCase converts a PascalCase/camelCase identifier to snake_case.
+func SnakeCase(s string) string {
+	if s == "" {
+		return ""
+	}
+	// Insert an underscore at every case boundary: "MyProject" -> "My_Project".
+	var b strings.Builder
+	runes := []rune(s)
+	for i, r := range runes {
+		if i > 0 && isUpper(r) && !isUpper(runes[i-1]) {
+			b.WriteByte('_')
+		}
+		if i > 0 && isUpper(r) && i+1 < len(runes) && isLower(runes[i+1]) && isLower(runes[i-1]) {
+			b.WriteByte('_')
+		}
+		b.WriteRune(r)
+	}
+	return strings.ToLower(nonWordSplitter.ReplaceAllString(b.String(), "_"))
+}
+
+func isUpper(r rune) bool { return r >= 'A' && r <= 'Z' }
+func isLower(r rune) bool { return r >= 'a' && r <= 'z' }
+
+// ShellQuote wraps s in single quotes, escaping any embedded single
+// quotes with the standard "'='"'"' trick.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+// renderStr renders s as a Go text/template against values, returning
+// s unchanged when it contains no template directives or fails to
+// parse/execute. This lets param prompts and defaults reference the
+// available values, e.g. `prompt = "Name for {{ .name }}"` or
+// `default = "{{ .name }}"`. The safe fallthrough means malformed or
+// non-templated strings never break scaffolding.
+func renderStr(s string, values map[string]any) string {
+	if s == "" || !strings.Contains(s, "{{") {
+		return s
+	}
+	t, err := template.New("param").Funcs(FuncMap()).Parse(s)
+	if err != nil {
+		return s
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, values); err != nil {
+		return s
+	}
+	return buf.String()
+}

--- a/internal/params/render_test.go
+++ b/internal/params/render_test.go
@@ -1,0 +1,80 @@
+package params
+
+import (
+	"testing"
+)
+
+// TestRenderStr verifies that prompt/default strings are rendered as
+// Go templates against the available values: bare strings pass
+// through, {{ .x }} interpolates, the shared helpers (snake_case,
+// upper, ...) work, and malformed input falls back to the raw string
+// instead of erroring.
+func TestRenderStr(t *testing.T) {
+	values := map[string]any{
+		"name":         "my-app",
+		"project_name": "my-app",
+	}
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"plain prompt", "plain prompt"},
+		{"Name for {{ .name }}", "Name for my-app"},
+		{"{{ .name }}", "my-app"},
+		{"{{ .name | upper }}", "MY-APP"},
+		{"{{ snake_case .name }}", "my_app"},
+		{"{{ kebab .name }}", "my-app"},
+		{"{{ .name | trim }}", "my-app"},
+		// malformed template -> safe fallback to the raw string.
+		{"oops {{ .name", "oops {{ .name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := renderStr(tc.in, values); got != tc.want {
+				t.Errorf("renderStr(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTextParam_TemplatedDefault verifies that a text param whose
+// default is a template string is resolved against the values map by
+// SetDefault, so `default = "{{ .name }}"` yields the project name.
+func TestTextParam_TemplatedDefault(t *testing.T) {
+	p := NewText("module", "Module name", "{{ .name }}")
+	p.SetDefault(map[string]any{"name": "my-app"})
+	if got := p.Value().String; got != "my-app" {
+		t.Errorf("templated default = %q, want %q", got, "my-app")
+	}
+}
+
+// TestSelectParam_TemplatedDefault verifies the same templating for a
+// select param's default.
+func TestSelectParam_TemplatedDefault(t *testing.T) {
+	p := NewSelect("edition", "Edition", []string{"2021", "2024"}, "{{ .ed }}")
+	p.SetDefault(map[string]any{"ed": "2024"})
+	if got := p.Value().String; got != "2024" {
+		t.Errorf("templated default = %q, want %q", got, "2024")
+	}
+}
+
+// TestFromAny verifies the value coercion used when seeding builtins
+// (name, project_name) onto params and by ResolveForm.
+func TestFromAny(t *testing.T) {
+	cases := []struct {
+		in   any
+		want Value
+	}{
+		{"s", Value{Kind: TypeText, String: "s"}},
+		{42, Value{Kind: TypeNumber, Int: 42}},
+		{true, Value{Kind: TypeBool, Bool: true}},
+		{[]string{"a", "b"}, Value{Kind: TypeMultiSelect, List: []string{"a", "b"}}},
+		{[]any{"x", "y"}, Value{Kind: TypeMultiSelect, List: []string{"x", "y"}}},
+	}
+	for _, tc := range cases {
+		got := FromAny(tc.in)
+		if got.Kind != tc.want.Kind {
+			t.Errorf("FromAny(%v).Kind = %q, want %q", tc.in, got.Kind, tc.want.Kind)
+		}
+	}
+}

--- a/internal/params/secret.go
+++ b/internal/params/secret.go
@@ -22,13 +22,15 @@ func (p *SecretParam) Name() string   { return p.name }
 func (p *SecretParam) Type() Type     { return TypeSecret }
 func (p *SecretParam) Prompt() string { return p.prompt }
 func (p *SecretParam) Default() any   { return p.def }
-func (p *SecretParam) SetDefault()    { p.Apply(Value{Kind: TypeSecret, String: p.def}) }
-func (p *SecretParam) Apply(v Value)  { p.value = v.String }
-func (p *SecretParam) Value() Value   { return Value{Kind: TypeSecret, String: p.value} }
-func (p *SecretParam) HuhField() huh.Field {
+func (p *SecretParam) SetDefault(values map[string]any) {
+	p.Apply(Value{Kind: TypeSecret, String: renderStr(p.def, values)})
+}
+func (p *SecretParam) Apply(v Value) { p.value = v.String }
+func (p *SecretParam) Value() Value  { return Value{Kind: TypeSecret, String: p.value} }
+func (p *SecretParam) HuhField(values map[string]any) huh.Field {
 	return huh.NewInput().
 		Key(p.name).
-		Title(orPrompt(p.name, p.prompt)).
+		Title(orPrompt(p.name, renderStr(p.prompt, values))).
 		EchoMode(huh.EchoModePassword).
 		Value(&p.value)
 }

--- a/internal/params/select.go
+++ b/internal/params/select.go
@@ -23,17 +23,19 @@ func (p *SelectParam) Name() string   { return p.name }
 func (p *SelectParam) Type() Type     { return TypeSelect }
 func (p *SelectParam) Prompt() string { return p.prompt }
 func (p *SelectParam) Default() any   { return p.def }
-func (p *SelectParam) SetDefault()    { p.Apply(Value{Kind: TypeSelect, String: p.def}) }
-func (p *SelectParam) Apply(v Value)  { p.value = v.String }
-func (p *SelectParam) Value() Value   { return Value{Kind: TypeSelect, String: p.value} }
-func (p *SelectParam) HuhField() huh.Field {
+func (p *SelectParam) SetDefault(values map[string]any) {
+	p.Apply(Value{Kind: TypeSelect, String: renderStr(p.def, values)})
+}
+func (p *SelectParam) Apply(v Value) { p.value = v.String }
+func (p *SelectParam) Value() Value  { return Value{Kind: TypeSelect, String: p.value} }
+func (p *SelectParam) HuhField(values map[string]any) huh.Field {
 	opts := make([]huh.Option[string], 0, len(p.options))
 	for _, o := range p.options {
 		opts = append(opts, huh.NewOption(o, o))
 	}
 	f := huh.NewSelect[string]().
 		Key(p.name).
-		Title(orPrompt(p.name, p.prompt)).
+		Title(orPrompt(p.name, renderStr(p.prompt, values))).
 		Options(opts...).
 		Value(&p.value)
 	if p.def != "" {

--- a/internal/params/text.go
+++ b/internal/params/text.go
@@ -21,16 +21,18 @@ func (p *TextParam) Name() string   { return p.name }
 func (p *TextParam) Type() Type     { return TypeText }
 func (p *TextParam) Prompt() string { return p.prompt }
 func (p *TextParam) Default() any   { return p.def }
-func (p *TextParam) SetDefault()    { p.Apply(Value{Kind: TypeText, String: p.def}) }
-func (p *TextParam) Apply(v Value)  { p.value = v.String }
-func (p *TextParam) Value() Value   { return Value{Kind: TypeText, String: p.value} }
-func (p *TextParam) HuhField() huh.Field {
+func (p *TextParam) SetDefault(values map[string]any) {
+	p.Apply(Value{Kind: TypeText, String: renderStr(p.def, values)})
+}
+func (p *TextParam) Apply(v Value) { p.value = v.String }
+func (p *TextParam) Value() Value  { return Value{Kind: TypeText, String: p.value} }
+func (p *TextParam) HuhField(values map[string]any) huh.Field {
 	f := huh.NewInput().
 		Key(p.name).
-		Title(orPrompt(p.name, p.prompt)).
+		Title(orPrompt(p.name, renderStr(p.prompt, values))).
 		Value(&p.value)
-	if p.def != "" {
-		f = f.Placeholder(p.def)
+	if r := renderStr(p.def, values); r != "" {
+		f = f.Placeholder(r)
 	}
 	return f
 }

--- a/internal/params/textarea.go
+++ b/internal/params/textarea.go
@@ -21,17 +21,19 @@ func (p *TextareaParam) Name() string   { return p.name }
 func (p *TextareaParam) Type() Type     { return TypeTextarea }
 func (p *TextareaParam) Prompt() string { return p.prompt }
 func (p *TextareaParam) Default() any   { return p.def }
-func (p *TextareaParam) SetDefault()    { p.Apply(Value{Kind: TypeTextarea, String: p.def}) }
-func (p *TextareaParam) Apply(v Value)  { p.value = v.String }
-func (p *TextareaParam) Value() Value   { return Value{Kind: TypeTextarea, String: p.value} }
-func (p *TextareaParam) HuhField() huh.Field {
+func (p *TextareaParam) SetDefault(values map[string]any) {
+	p.Apply(Value{Kind: TypeTextarea, String: renderStr(p.def, values)})
+}
+func (p *TextareaParam) Apply(v Value) { p.value = v.String }
+func (p *TextareaParam) Value() Value  { return Value{Kind: TypeTextarea, String: p.value} }
+func (p *TextareaParam) HuhField(values map[string]any) huh.Field {
 	f := huh.NewText().
 		Key(p.name).
-		Title(orPrompt(p.name, p.prompt)).
+		Title(orPrompt(p.name, renderStr(p.prompt, values))).
 		CharLimit(0).
 		Value(&p.value)
-	if p.def != "" {
-		f = f.Placeholder(p.def)
+	if r := renderStr(p.def, values); r != "" {
+		f = f.Placeholder(r)
 	}
 	return f
 }

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -6,14 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
-	"slices"
 	"strings"
 	"text/template"
-	"time"
-
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 func renderFile(path string, values map[string]any, funcs template.FuncMap) ([]byte, error) {
@@ -30,89 +24,6 @@ func renderFile(path string, values map[string]any, funcs template.FuncMap) ([]b
 		return nil, err
 	}
 	return buf.Bytes(), nil
-}
-
-func funcMap() template.FuncMap {
-	titleCaser := cases.Title(language.English)
-	return template.FuncMap{
-		// Useful in templates
-		"upper": strings.ToUpper,
-		"lower": strings.ToLower,
-		"title": titleCaser.String,
-		"trim":  strings.TrimSpace,
-		"join":  strings.Join,
-		"default": func(d, v any) any {
-			if v == nil || v == "" {
-				return d
-			}
-			return v
-		},
-		// snake_case: "MyProject" -> "my_project".
-		// Splits on case boundaries and word boundaries, joins
-		// with underscores, lowercases.
-		"snake_case": snakeCase,
-		// kebab-case: "MyProject" -> "my-project". Go's text/template
-		// requires function names to be valid identifiers, so we use
-		// `kebab` (called as `{{ kebab "X" }}`).
-		"kebab": func(s string) string {
-			return strings.ReplaceAll(snakeCase(s), "_", "-")
-		},
-		// quote: shell-escapes s for use inside a `[[post]] run = "..."`.
-		// Uses single-quote wrapping with the standard "'='"'" trick
-		// so embedded single quotes are escaped correctly.
-		"quote": shellQuote,
-		// now: current time, formatted. No-arg -> RFC3339. With a
-		// layout string (e.g. "2006") -> that layout.
-		"now": func(layout string) string {
-			if layout == "" {
-				layout = time.RFC3339
-			}
-			return time.Now().UTC().Format(layout)
-		},
-		// contains: substring check. Useful in templates that want
-		// to gate on a value (e.g. `{{ if contains .tags "rust" }}`).
-		"contains": strings.Contains,
-		// has: report whether a []string contains a value. Used by
-		// [[include]] rules and conditional templates.
-		"has": slices.Contains[[]string, string],
-		// not_has: inverse of has.
-		"not_has": func(list []string, item string) bool {
-			return !slices.Contains(list, item)
-		},
-		// one_of: report whether a value equals any of the given strings.
-		"one_of": func(v string, items ...string) bool {
-			return slices.Contains(items, v)
-		},
-	}
-}
-
-var nonWordSplitter = regexp.MustCompile(`[^a-zA-Z0-9]+`)
-
-func snakeCase(s string) string {
-	if s == "" {
-		return ""
-	}
-	// Insert an underscore at every case boundary: "MyProject" -> "My_Project".
-	var b strings.Builder
-	runes := []rune(s)
-	for i, r := range runes {
-		if i > 0 && isUpper(r) && !isUpper(runes[i-1]) {
-			b.WriteByte('_')
-		}
-		if i > 0 && isUpper(r) && i+1 < len(runes) && isLower(runes[i+1]) && isLower(runes[i-1]) {
-			b.WriteByte('_')
-		}
-		b.WriteRune(r)
-	}
-	return strings.ToLower(nonWordSplitter.ReplaceAllString(b.String(), "_"))
-}
-
-func isUpper(r rune) bool { return r >= 'A' && r <= 'Z' }
-func isLower(r rune) bool { return r >= 'a' && r <= 'z' }
-
-func shellQuote(s string) string {
-	// 'foo' -> 'foo'. Embedded single quotes become '"'"'.
-	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 }
 
 // writeFiles writes a rel-path → bytes map to a destination directory.

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -3,6 +3,8 @@ package template
 import (
 	"strings"
 	"testing"
+
+	"github.com/N1xev/spin/internal/params"
 )
 
 // TestSnakeCase verifies the snakeCase helper that converts
@@ -22,7 +24,7 @@ func TestSnakeCase(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.in, func(t *testing.T) {
-			got := snakeCase(c.in)
+			got := params.SnakeCase(c.in)
 			if got != c.want {
 				t.Errorf("snakeCase(%q) = %q, want %q", c.in, got, c.want)
 			}
@@ -43,7 +45,7 @@ func TestShellQuote(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.in, func(t *testing.T) {
-			got := shellQuote(c.in)
+			got := params.ShellQuote(c.in)
 			if got != c.want {
 				t.Errorf("shellQuote(%q) = %q, want %q", c.in, got, c.want)
 			}
@@ -54,7 +56,7 @@ func TestShellQuote(t *testing.T) {
 // TestFuncMapHelpers verifies the key template helpers registered
 // by funcMap(), ensuring they produce the expected input→output.
 func TestFuncMapHelpers(t *testing.T) {
-	fm := funcMap()
+	fm := params.FuncMap()
 
 	t.Run("upper", func(t *testing.T) {
 		fn, ok := fm["upper"]

--- a/internal/template/form.go
+++ b/internal/template/form.go
@@ -23,7 +23,7 @@ func (t *Template) BuildForm(values map[string]any) (*huh.Form, error) {
 			p.Apply(toParamValue(v))
 		}
 	}
-	form := params.Form(ps)
+	form := params.Form(ps, values)
 	// After Run, walk the params and copy their Values into values.
 	// We attach a callback by using huh's Key() -- but huh doesn't have
 	// a generic "post-run" hook. So we expose a separate helper.
@@ -48,9 +48,9 @@ func (t *Template) ResolveForm(values map[string]any, interactive bool) (map[str
 		return nil, err
 	}
 	if !interactive {
-		params.SetDefaults(ps)
+		params.SetDefaults(ps, values)
 	} else {
-		if err := params.Run(ps); err != nil {
+		if err := params.Run(ps, values); err != nil {
 			return nil, err
 		}
 	}
@@ -60,6 +60,12 @@ func (t *Template) ResolveForm(values map[string]any, interactive bool) (map[str
 		if v, ok := values[p.Name()]; ok {
 			p.Apply(toParamValue(v))
 		}
+	}
+	// huh validates select values on submit in interactive mode, but
+	// the non-interactive path (and --param overrides) skip that, so
+	// reject a select value outside its options here.
+	if err := params.ValidateDefaults(ps); err != nil {
+		return nil, err
 	}
 	out := map[string]any{}
 	for _, p := range ps {
@@ -78,25 +84,7 @@ func (t *Template) ResolveForm(values map[string]any, interactive bool) (map[str
 }
 
 func toParamValue(v any) params.Value {
-	switch x := v.(type) {
-	case string:
-		return params.Value{Kind: params.TypeText, String: x}
-	case int:
-		return params.Value{Kind: params.TypeNumber, Int: x}
-	case bool:
-		return params.Value{Kind: params.TypeBool, Bool: x}
-	case []string:
-		return params.Value{Kind: params.TypeMultiSelect, List: x}
-	case []any:
-		out := make([]string, 0, len(x))
-		for _, item := range x {
-			if s, ok := item.(string); ok {
-				out = append(out, s)
-			}
-		}
-		return params.Value{Kind: params.TypeMultiSelect, List: out}
-	}
-	return params.Value{}
+	return params.FromAny(v)
 }
 
 // UnwrapValue returns the underlying primitive held by a

--- a/internal/template/form_test.go
+++ b/internal/template/form_test.go
@@ -1,0 +1,96 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/N1xev/spin/internal/params"
+)
+
+// TestResolveForm_BuiltinsSeededAndCopiedThrough verifies the
+// SSOT contract between the TTY (runNewTUI) and non-TTY
+// (ResolveForm) paths: builtins (name, project_name) supplied up
+// front win over a param's own default, and builtins that are not
+// backed by a param are copied through to the result so templates
+// referencing {{ .project_name }} still render.
+func TestResolveForm_BuiltinsSeededAndCopiedThrough(t *testing.T) {
+	tpl := &Template{
+		SpinToml: &SpinToml{
+			Params: map[string]params.Spec{
+				"name":  {Type: params.TypeText, Default: "fallback"},
+				"color": {Type: params.TypeText, Default: "blue"},
+			},
+		},
+	}
+	values := map[string]any{
+		"name":         "cli-name",
+		"project_name": "cli-name",
+	}
+	out, err := tpl.ResolveForm(values, false)
+	if err != nil {
+		t.Fatalf("ResolveForm: %v", err)
+	}
+	if out["name"] != "cli-name" {
+		t.Errorf("name = %v, want cli-name (builtin should override default)", out["name"])
+	}
+	if out["color"] != "blue" {
+		t.Errorf("color = %v, want blue (default)", out["color"])
+	}
+	if out["project_name"] != "cli-name" {
+		t.Errorf("project_name = %v, want cli-name (copied through)", out["project_name"])
+	}
+}
+
+// TestResolveForm_TemplatedDefault verifies that a param default
+// written as a template string is rendered against the available
+// values during non-interactive resolution.
+func TestResolveForm_TemplatedDefault(t *testing.T) {
+	tpl := &Template{
+		SpinToml: &SpinToml{
+			Params: map[string]params.Spec{
+				"module": {Type: params.TypeText, Default: "{{ .name }}"},
+			},
+		},
+	}
+	out, err := tpl.ResolveForm(map[string]any{"name": "my-app"}, false)
+	if err != nil {
+		t.Fatalf("ResolveForm: %v", err)
+	}
+	if out["module"] != "my-app" {
+		t.Errorf("module = %v, want my-app (templated default)", out["module"])
+	}
+}
+
+// TestResolveForm_SelectDefaultOutsideOptions verifies that a select
+// default rendered outside the option list is rejected in the
+// non-interactive path (huh's per-field Validate does not run there).
+func TestResolveForm_SelectDefaultOutsideOptions(t *testing.T) {
+	tpl := &Template{
+		SpinToml: &SpinToml{
+			Params: map[string]params.Spec{
+				"edition": {Type: params.TypeSelect, Options: []string{"2021", "2024"}, Default: "{{ .ed }}"},
+			},
+		},
+	}
+	if _, err := tpl.ResolveForm(map[string]any{"ed": "2030"}, false); err == nil {
+		t.Fatal("expected error for select default outside options, got nil")
+	}
+}
+
+// TestResolveForm_SelectDefaultInOptions verifies a valid templated
+// select default still resolves cleanly through the same path.
+func TestResolveForm_SelectDefaultInOptions(t *testing.T) {
+	tpl := &Template{
+		SpinToml: &SpinToml{
+			Params: map[string]params.Spec{
+				"edition": {Type: params.TypeSelect, Options: []string{"2021", "2024"}, Default: "{{ .ed }}"},
+			},
+		},
+	}
+	out, err := tpl.ResolveForm(map[string]any{"ed": "2024"}, false)
+	if err != nil {
+		t.Fatalf("ResolveForm: %v", err)
+	}
+	if out["edition"] != "2024" {
+		t.Errorf("edition = %v, want 2024", out["edition"])
+	}
+}

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/N1xev/spin/internal/params"
 )
 
 // Template is a loaded external template, ready to render.
@@ -73,7 +75,7 @@ func (t *Template) Render(values map[string]any) (map[string][]byte, error) {
 	out := map[string][]byte{}
 	// Build the template helpers once and reuse them for every file
 	// and every [[include]] rule in this pass.
-	funcs := funcMap()
+	funcs := params.FuncMap()
 	err := filepath.Walk(t.BaseDir, func(path string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
 			return walkErr

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -663,7 +663,7 @@ func TestShouldInclude_IsDir(t *testing.T) {
 			},
 		},
 	}
-	funcs := funcMap()
+	funcs := params.FuncMap()
 
 	// A file matching the rule with ci=false → not included.
 	inc, skip, err := tpl.shouldInclude("opt/f.go", "opt/f.go", false, map[string]any{"ci": false}, funcs)


### PR DESCRIPTION
## Summary of this PR <:

  This PR extends `spin.toml` params so `prompt` and `default` can use the same Go-template helpers already available in `_base/` files and hooks, and cleans up the shared template-helper plumbing so it lives in one place.

## What's changed

- **Template helpers are now shared.** `upper`, `snake_case`, `quote`, `kebab`, `has`, etc. are exported from `internal/params` and consumed by both the file renderer and the param system.
- **Params support templated prompts and defaults.** A
param can now write:
```toml
[params]
project_name = { type = "text", prompt = "Project name" }
module       = { type = "text", default = "github.com/me/{{ .project_name }}" }
db_name      = { type = "text", default = "{{ snake_case .project_name }}" }
```
- TUI parity fix. The interactive form now receives built-in values ( name ,  project_name ) and any  --param  overrides before it opens, so the TTY and non-TTY paths produce the same resolved map.
- Select validation in non-interactive mode. A  select  default or  --param  value that resolves outside the declared options  now errors instead of producing a project with an invalid value.
- Safe fallback. Malformed or undefined template references fall back to the raw string, so a typo in a prompt never aborts a scaffold.

## Scope

- New:  `internal/params/render.go` ,  `internal/params/render_test.go` ,  `internal/template/form_test.go`
- Updated:  `internal/params/*.go` ,  `internal/template/*.go` ,  `cmd/new.go` ,  `cmd/new_tui.go`

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`