### PR TITLE
Feat/brand theme

### DIFF
--- a/cmd/hook_output.go
+++ b/cmd/hook_output.go
@@ -10,6 +10,8 @@ import (
 
 	"charm.land/lipgloss/v2"
 	tree "charm.land/lipgloss/v2/tree"
+
+	"github.com/N1xev/spin/internal/theme"
 )
 
 // hookSiblings is a dummy two-element Children used to derive lipgloss'
@@ -20,7 +22,7 @@ var hookSiblings = tree.NewStringData("a", "b")
 // It is the pipe mark from lipgloss/tree's DefaultIndenter plus a space.
 var hookIndent = strings.TrimRight(tree.DefaultIndenter(hookSiblings, 0), " ") + " "
 
-var hookBodyStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+var hookBodyStyle = lipgloss.NewStyle().Foreground(theme.TextDimmed)
 
 // hookTreeWriter buffers hook stdout/stderr and emits each complete line
 // with the tree continuation indent in a dim colour. Headers are emitted
@@ -86,7 +88,7 @@ func channelHookOutput(ch chan<- string) io.Writer {
 // hookStepHeader renders a styled pre/post hook step header line.
 func hookStepHeader(kind, cmd string) string {
 	mark := tree.DefaultEnumerator(hookSiblings, 0)
-	node := lipgloss.NewStyle().Foreground(tuiAccent).Bold(true).
+	node := lipgloss.NewStyle().Foreground(theme.Accent).Bold(true).
 		Render(mark + " " + kind + "-hook")
 	return fmt.Sprintf("%s %s\n", node, cmd)
 }

--- a/cmd/hooks_tui.go
+++ b/cmd/hooks_tui.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/N1xev/spin/internal/template"
+	"github.com/N1xev/spin/internal/theme"
 )
 
 // hookItem adapts a template.HookView to the bubbles list.Item interface.
@@ -117,8 +118,10 @@ func newHooksModel(tpl *template.Template, styles *tuiStyles, width, height int,
 	}
 
 	delegate := list.NewDefaultDelegate()
+	delegate.Styles = theme.ListItemStyles()
 	listH := max(height-7, 1)
 	l := list.New(listItems, delegate, hooksListContentW, listH)
+	l.Styles = theme.ListStyles()
 	l.SetShowTitle(false)
 	l.SetShowFilter(false)
 	l.SetShowStatusBar(false)
@@ -213,19 +216,19 @@ func (m hooksModel) update(msg tea.Msg) (hooksModel, tea.Cmd) {
 	case runDoneMsg:
 		m.running = false
 		if msg.err != nil {
-			m.output += "\n" + lipgloss.NewStyle().Foreground(tuiBrightRed).Render("error: "+msg.err.Error())
+			m.output += "\n" + lipgloss.NewStyle().Foreground(theme.StatusError).Render("error: "+msg.err.Error())
 			m.viewport.SetContent(wrapForView(m.output, m.viewport.Width()))
 			m.viewport.GotoBottom()
 			return m, nil
 		}
-		m.output += "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Render("done.")
+		m.output += "\n" + lipgloss.NewStyle().Foreground(theme.StatusInfo).Render("done.")
 		// Mirror the success summary into the pane so the user
 		// sees it before quitting. runNew reprints the same two
 		// lines on the restored terminal once they press q.
 		m.output += "\n"
-		m.output += lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Render(
+		m.output += lipgloss.NewStyle().Foreground(theme.StatusSuccess).Render(
 			fmt.Sprintf("INFO created %s at %s", m.name, m.dest))
-		m.output += "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render(
+		m.output += "\n" + lipgloss.NewStyle().Foreground(theme.TextDimmed).Render(
 			fmt.Sprintf("cd %s", m.dest))
 		m.viewport.SetContent(wrapForView(m.output, m.viewport.Width()))
 		m.viewport.GotoBottom()
@@ -384,8 +387,8 @@ func (m hooksModel) appBoundaryView(text string) string {
 		m.width,
 		lipgloss.Left,
 		m.styles.HeaderText.Render(text),
-		lipgloss.WithWhitespaceChars("/"),
-		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Foreground(tuiAccent)),
+		lipgloss.WithWhitespaceChars(theme.BoundaryChar),
+		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Foreground(theme.Accent)),
 	)
 }
 
@@ -394,8 +397,8 @@ func (m hooksModel) appBoundaryViewFoot(text string) string {
 		m.width,
 		lipgloss.Left,
 		lipgloss.NewStyle().PaddingRight(1).Render(text),
-		lipgloss.WithWhitespaceChars("/"),
-		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Foreground(tuiAccent)),
+		lipgloss.WithWhitespaceChars(theme.BoundaryChar),
+		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Foreground(theme.Accent)),
 	)
 }
 
@@ -417,15 +420,15 @@ func (m hooksModel) resize(width, height int) hooksModel {
 
 func (m hooksModel) view() tea.View {
 	s := m.styles
-	title := gradientText("Spin  Hooks Review — "+m.name, tuiPink, tuiAccent)
+	title := gradientText("Spin  Hooks Review — "+m.name, theme.AccentAlt, theme.Accent)
 	header := m.appBoundaryView(title)
 
 	listStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(tuiAccent).
+		BorderForeground(theme.Accent).
 		Padding(1, 0)
 	if m.focus == "list" && !m.modalOpen {
-		listStyle = listStyle.BorderForeground(tuiBrightRed)
+		listStyle = listStyle.BorderForeground(theme.StatusError)
 	}
 	listBox := listStyle.
 		Width(hooksListContentW + hooksListBorderW).
@@ -434,11 +437,11 @@ func (m hooksModel) view() tea.View {
 
 	viewStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(tuiAccent).
+		BorderForeground(theme.Accent).
 		Padding(1, 0)
 
 	if m.focus == "view" && !m.modalOpen {
-		viewStyle = viewStyle.BorderForeground(tuiBrightYellow)
+		viewStyle = viewStyle.BorderForeground(theme.StatusWarning)
 	}
 	viewBox := viewStyle.
 		Width(max(m.viewport.Width(), hooksViewMinW) + hooksViewBorderW).
@@ -492,10 +495,12 @@ func (m hooksModel) view() tea.View {
 		canvas.Compose(comp)
 		v := tea.NewView(canvas.Render())
 		v.AltScreen = true
+		v.BackgroundColor = theme.ViewBg
 		return v
 	}
 	v := tea.NewView(s.Base.Render(inner))
 	v.AltScreen = true
+	v.BackgroundColor = theme.ViewBg
 	return v
 }
 
@@ -518,11 +523,11 @@ func (m hooksModel) modalBox() string {
 	cancelStyle := lipgloss.NewStyle()
 	switch m.modalChoice {
 	case 0:
-		runStyle = runStyle.Foreground(tuiBrightRed).Bold(true)
+		runStyle = runStyle.Foreground(theme.StatusError).Bold(true)
 	case 1:
-		skipStyle = skipStyle.Foreground(tuiBrightYellow).Bold(true)
+		skipStyle = skipStyle.Foreground(theme.StatusWarning).Bold(true)
 	default:
-		cancelStyle = cancelStyle.Foreground(lipgloss.Color("245")).Bold(true)
+		cancelStyle = cancelStyle.Foreground(theme.TextDimmed).Bold(true)
 	}
 	fmt.Fprintf(&b, "\n  %s    %s    %s\n",
 		runStyle.Render("Run"),
@@ -531,7 +536,7 @@ func (m hooksModel) modalBox() string {
 
 	boxStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(tuiAccent).
+		BorderForeground(theme.Accent).
 		Padding(1, 3)
 	return boxStyle.Render(b.String())
 }

--- a/cmd/new_prompts.go
+++ b/cmd/new_prompts.go
@@ -15,6 +15,7 @@ import (
 	"github.com/N1xev/spin/internal/log"
 	"github.com/N1xev/spin/internal/registry"
 	"github.com/N1xev/spin/internal/template"
+	"github.com/N1xev/spin/internal/theme"
 )
 
 func printHooks(tpl *template.Template) {
@@ -99,7 +100,7 @@ func dryRunRender(ctx context.Context, tpl *template.Template, values map[string
 // Asks "keep the broken clone, or remove it?"
 func promptInvalidPinned(name, localPath string, detectErr error) (bool, error) {
 	var keep bool
-	form := huh.NewForm(
+	form := theme.NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title(fmt.Sprintf("Template %q is broken -- keep it?", name)).
@@ -123,7 +124,7 @@ func promptInvalidPinned(name, localPath string, detectErr error) (bool, error) 
 // source for offline use; Wipe re-clones; Cancel aborts.
 func promptExistingDest(name, localPath string) (template.DestAction, error) {
 	var action string
-	form := huh.NewForm(
+	form := theme.NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title(fmt.Sprintf("%q already exists at %s", name, localPath)).
@@ -166,7 +167,7 @@ func promptPinAfterSuccess(ctx context.Context, _ string, tpl *template.Template
 		}
 	}
 	var pin bool
-	form := huh.NewForm(
+	form := theme.NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title(fmt.Sprintf("Pin %q for offline use?", tpl.Name)).
@@ -209,7 +210,7 @@ func pinnedSnapshot(ctx context.Context, client *registry.Client) []registry.Pin
 // Returns true if the user confirms.
 func promptOverwriteExisting(name string, dir string) bool {
 	var overwrite bool
-	form := huh.NewForm(
+	form := theme.NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title(fmt.Sprintf("Directory %q already exists", name)).
@@ -229,7 +230,7 @@ func promptOverwriteExisting(name string, dir string) bool {
 // 130 on cancel.
 func promptForName() (string, error) {
 	var name string
-	form := huh.NewForm(
+	form := theme.NewForm(
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Project name").
@@ -277,7 +278,7 @@ func promptForTemplate(ctx context.Context) (string, error) {
 	for _, n := range names {
 		opts = append(opts, huh.NewOption(n, n))
 	}
-	form := huh.NewForm(
+	form := theme.NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Pick a pinned template").

--- a/cmd/new_tui.go
+++ b/cmd/new_tui.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"image/color"
+	"os"
 	"strings"
 
 	"charm.land/bubbles/v2/viewport"
@@ -11,18 +12,9 @@ import (
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
 
-	"os"
-
 	"github.com/N1xev/spin/internal/params"
 	"github.com/N1xev/spin/internal/template"
-)
-
-var (
-	tuiAccent       = lipgloss.Color("99")
-	tuiPink         = lipgloss.Color("212")
-	tuiRed          = lipgloss.Color("9")
-	tuiBrightRed    = lipgloss.Color("#FF5555")
-	tuiBrightYellow = lipgloss.Color("#F1FA8C")
+	"github.com/N1xev/spin/internal/theme"
 )
 
 type tuiStyles struct {
@@ -33,15 +25,15 @@ func newTUIStyles() *tuiStyles {
 	return &tuiStyles{
 		Base: lipgloss.NewStyle().Padding(1, 4, 0, 1),
 		HeaderText: lipgloss.NewStyle().
-			Foreground(tuiAccent).Bold(true).Padding(0, 1, 0, 2),
+			Foreground(theme.Accent).Bold(true).Padding(0, 1, 0, 2),
 		ErrorHeaderText: lipgloss.NewStyle().
-			Foreground(tuiRed).Bold(true).Padding(0, 1, 0, 2),
+			Foreground(theme.ErrorFg).Bold(true).Padding(0, 1, 0, 2),
 		Status: lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(tuiAccent).
+			BorderForeground(theme.Accent).
 			PaddingLeft(1).MarginTop(1),
 		StatusHeader: lipgloss.NewStyle().
-			Foreground(tuiAccent).Bold(true),
+			Foreground(theme.Accent).Bold(true),
 	}
 }
 
@@ -99,6 +91,7 @@ func newNewTUIModel(tpl *template.Template, values map[string]any) (newTUIModel,
 		fields = append(fields, p.HuhField(values))
 	}
 	m.form = huh.NewForm(huh.NewGroup(fields...)).
+		WithTheme(huh.ThemeFunc(func(_ bool) *huh.Styles { return theme.Theme() })).
 		WithWidth(min(m.width/2, 60)).
 		WithShowHelp(false).
 		WithShowErrors(false)
@@ -108,7 +101,9 @@ func newNewTUIModel(tpl *template.Template, values map[string]any) (newTUIModel,
 	return m, nil
 }
 
-func (m newTUIModel) Init() tea.Cmd { return m.form.Init() }
+func (m newTUIModel) Init() tea.Cmd {
+	return m.form.Init()
+}
 
 func (m newTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
@@ -185,7 +180,7 @@ func (m newTUIModel) View() tea.View {
 func (m newTUIModel) formView() tea.View {
 	s := m.styles
 
-	title := gradientText("Spin  Create Project — "+m.tpl.Name, tuiPink, tuiAccent)
+	title := gradientText("Spin  Create Project — "+m.tpl.Name, theme.AccentAlt, theme.Accent)
 
 	v := strings.TrimSuffix(m.form.View(), "\n\n")
 	form := lipgloss.NewStyle().Margin(1, 0).Render(v)
@@ -198,13 +193,14 @@ func (m newTUIModel) formView() tea.View {
 		header = m.appErrorBoundaryView(errorView(errors))
 	}
 	body := lipgloss.JoinHorizontal(lipgloss.Left, form, status)
-	footer := m.appBoundaryViewFoot(m.form.WithWidth(m.width-10).Help().ShortHelpView(m.form.KeyBinds()) + lipgloss.NewStyle().Foreground(lipgloss.Color("#4A4A4A")).Render(" • ") + lipgloss.NewStyle().Foreground(lipgloss.Color("#626262")).Render("ctrl+↑/↓") + lipgloss.NewStyle().Foreground(lipgloss.Color("#4A4A4A")).Render(" scroll preview"))
+	footer := m.appBoundaryViewFoot(m.form.WithWidth(m.width-10).Help().ShortHelpView(m.form.KeyBinds()) + lipgloss.NewStyle().Foreground(theme.TextDimmed).Render(" • ") + lipgloss.NewStyle().Foreground(theme.Accent).Render("ctrl+↑/↓") + lipgloss.NewStyle().Foreground(theme.TextMuted).Render(" scroll preview"))
 	m.form = m.form.WithWidth(min(m.width/2, 60))
 	if len(errors) > 0 {
 		footer = m.appErrorBoundaryView("")
 	}
 	hv := tea.NewView(s.Base.Render(header + "\n" + body + "\n\n" + footer))
 	hv.AltScreen = true
+	hv.BackgroundColor = theme.ViewBg
 	return hv
 }
 
@@ -215,14 +211,14 @@ func (m newTUIModel) statusView(form string) string {
 		return ""
 	}
 	w := max(m.width-fw-4, 50)
-	label := lipgloss.NewStyle().Foreground(tuiAccent)
-	cmdStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Italic(true)
-	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	label := lipgloss.NewStyle().Foreground(theme.Accent)
+	cmdStyle := lipgloss.NewStyle().Foreground(theme.TextDimmed).Italic(true)
+	dim := lipgloss.NewStyle().Foreground(theme.TextDimmed)
 	thdr := func(text string, c color.Color) string {
 		return lipgloss.NewStyle().Foreground(c).Bold(true).Render(text)
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s\n", thdr("Template", lipgloss.Color("14")))
+	fmt.Fprintf(&b, "%s\n", thdr("Template", theme.StatusInfo))
 	fmt.Fprintf(&b, "%s\n", m.tpl.Name)
 	if m.tpl.SpinToml != nil {
 		if m.tpl.SpinToml.Description != "" {
@@ -235,7 +231,7 @@ func (m newTUIModel) statusView(form string) string {
 			fmt.Fprintf(&b, "Type: %s\n", m.tpl.SpinToml.Type)
 		}
 		if len(m.tpl.SpinToml.Pre)+len(m.tpl.SpinToml.Post) > 0 {
-			fmt.Fprintf(&b, "\n%s\n", thdr("Hooks", tuiBrightRed))
+			fmt.Fprintf(&b, "\n%s\n", thdr("Hooks", theme.StatusError))
 			for _, pre := range m.tpl.SpinToml.Pre {
 				fmt.Fprintf(&b, "  %s %s\n", label.Render("pre:"), cmdStyle.Render(pre.Run))
 			}
@@ -245,7 +241,7 @@ func (m newTUIModel) statusView(form string) string {
 		}
 		if d := m.tpl.PreHookDir; d != "" {
 			if es, _ := os.ReadDir(d); len(es) > 0 {
-				fmt.Fprintf(&b, "\n%s\n", thdr("_pre/ scripts", tuiBrightRed))
+				fmt.Fprintf(&b, "\n%s\n", thdr("_pre/ scripts", theme.StatusError))
 				for _, e := range es {
 					if !e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
 						fmt.Fprintf(&b, "  %s\n", dim.Render(e.Name()))
@@ -255,7 +251,7 @@ func (m newTUIModel) statusView(form string) string {
 		}
 		if d := m.tpl.PostHookDir; d != "" {
 			if es, _ := os.ReadDir(d); len(es) > 0 {
-				fmt.Fprintf(&b, "\n%s\n", thdr("_post/ scripts", tuiBrightRed))
+				fmt.Fprintf(&b, "\n%s\n", thdr("_post/ scripts", theme.StatusError))
 				for _, e := range es {
 					if !e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
 						fmt.Fprintf(&b, "  %s\n", dim.Render(e.Name()))
@@ -264,7 +260,7 @@ func (m newTUIModel) statusView(form string) string {
 			}
 		}
 	}
-	fmt.Fprintf(&b, "\n%s\n", thdr("Params", tuiBrightYellow))
+	fmt.Fprintf(&b, "\n%s\n", thdr("Params", theme.StatusWarning))
 	for _, p := range m.params {
 		if val := paramDisplay(p); val != "" {
 			fmt.Fprintf(&b, "  %s: %s\n", p.Name(), val)
@@ -327,8 +323,8 @@ func (m newTUIModel) appBoundaryView(text string) string {
 		m.width,
 		lipgloss.Left,
 		m.styles.HeaderText.Render(text),
-		lipgloss.WithWhitespaceChars("/"),
-		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Foreground(tuiAccent)),
+		lipgloss.WithWhitespaceChars(theme.BoundaryChar),
+		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Foreground(theme.Accent)),
 	)
 }
 
@@ -337,8 +333,8 @@ func (m newTUIModel) appErrorBoundaryView(text string) string {
 		m.width,
 		lipgloss.Left,
 		m.styles.ErrorHeaderText.Render(text),
-		lipgloss.WithWhitespaceChars("/"),
-		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Foreground(tuiRed)),
+		lipgloss.WithWhitespaceChars(theme.BoundaryChar),
+		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Foreground(theme.StatusError)),
 	)
 }
 
@@ -347,8 +343,8 @@ func (m newTUIModel) appBoundaryViewFoot(text string) string {
 		m.width,
 		lipgloss.Left,
 		lipgloss.NewStyle().PaddingRight(1).Render(text),
-		lipgloss.WithWhitespaceChars("/"),
-		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Foreground(tuiAccent)),
+		lipgloss.WithWhitespaceChars(theme.BoundaryChar),
+		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Foreground(theme.Accent)),
 	)
 }
 

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -12,12 +12,13 @@ import (
 	"golang.org/x/term"
 
 	"github.com/N1xev/spin/internal/log"
+	"github.com/N1xev/spin/internal/theme"
 )
 
 var (
-	styleHeader = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("99"))
+	styleHeader = lipgloss.NewStyle().Bold(true).Foreground(theme.Accent)
 	styleCell   = lipgloss.NewStyle()
-	styleBorder = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	styleBorder = lipgloss.NewStyle().Foreground(theme.TextDimmed)
 )
 
 func printSuccess(format string, args ...any) {
@@ -32,7 +33,7 @@ func printWarn(format string, args ...any) {
 func printHint(format string, args ...any) {
 	style := lipgloss.NewStyle().
 		MarginTop(1).
-		Foreground(lipgloss.Color("245")).
+		Foreground(theme.TextDimmed).
 		Italic(true)
 	fmt.Fprintln(os.Stdout, style.Render(fmt.Sprintf(format, args...)))
 }

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -1,0 +1,160 @@
+package theme
+
+import (
+	"image/color"
+	"os"
+
+	"charm.land/bubbles/v2/list"
+	"charm.land/fang/v2"
+	"charm.land/huh/v2"
+	huhspinner "charm.land/huh/v2/spinner"
+	"charm.land/lipgloss/v2"
+)
+
+var (
+	isDark = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+	ld     = lipgloss.LightDark(isDark)
+
+	orange        = lipgloss.Color("#ff5a1f")
+	orangeSoft    = lipgloss.Color("#fdba74")
+	orangeVibrant = lipgloss.Color("#ff7a45")
+	orangeDark    = lipgloss.Color("#e84a0a")
+
+	warmGray           = lipgloss.Color("#a5a4a1")
+	warmGraySoft       = lipgloss.Color("#dcd3c4")
+	warmGrayLight      = lipgloss.Color("#e5ddd0")
+	warmGrayLightest   = lipgloss.Color("#f2ede4")
+	warmGraySuperLight = lipgloss.Color("#fbfaf7")
+	warmGrayDim        = lipgloss.Color("#78716c")
+	warmGrayTone       = lipgloss.Color("#57534e")
+	warmGrayDark       = lipgloss.Color("#44403c")
+	warmGrayDarker     = lipgloss.Color("#2c2a26")
+	warmGrayDarkest    = lipgloss.Color("#0c0a09")
+
+	Accent      = ld(orange, orangeVibrant)
+	AccentAlt   = ld(orangeVibrant, orangeSoft)
+	text        = ld(warmGrayDark, warmGrayLightest)
+	TextMuted   = ld(warmGrayDim, warmGray)
+	TextDimmed  = ld(warmGray, warmGrayDim)
+	textSubdued = ld(warmGraySoft, warmGrayTone)
+
+	StatusError   = ld(orangeDark, lipgloss.Color("#ED567A"))
+	StatusSuccess = ld(lipgloss.Color("#15803d"), lipgloss.Color("#4ade80"))
+	StatusInfo    = ld(lipgloss.Color("#1d4ed8"), lipgloss.Color("#60a5fa"))
+	StatusWarning = orangeSoft
+
+	ErrorFg = ld(orangeDark, lipgloss.Color("9"))
+	ViewBg  = ld(warmGraySuperLight, warmGrayDarkest)
+
+	BoundaryChar = "/"
+)
+
+func Theme() *huh.Styles {
+	t := huh.ThemeBase(isDark)
+	border := ld(orangeSoft, warmGrayTone)
+	mutedBg := ld(warmGrayLight, warmGrayDark)
+
+	t.Focused.Base = t.Focused.Base.BorderForeground(border)
+	t.Focused.Card = t.Focused.Base
+	t.Focused.Title = t.Focused.Title.Foreground(Accent).Bold(true)
+	t.Focused.NoteTitle = t.Focused.NoteTitle.Foreground(Accent).Bold(true).MarginBottom(1)
+	t.Focused.Directory = t.Focused.Directory.Foreground(AccentAlt)
+	t.Focused.File = t.Focused.File.Foreground(text)
+	t.Focused.Description = t.Focused.Description.Foreground(TextMuted)
+	t.Focused.ErrorIndicator = t.Focused.ErrorIndicator.Foreground(StatusError)
+	t.Focused.ErrorMessage = t.Focused.ErrorMessage.Foreground(StatusError)
+	t.Focused.SelectSelector = t.Focused.SelectSelector.Foreground(Accent)
+	t.Focused.NextIndicator = t.Focused.NextIndicator.Foreground(AccentAlt)
+	t.Focused.PrevIndicator = t.Focused.PrevIndicator.Foreground(AccentAlt)
+	t.Focused.Option = t.Focused.Option.Foreground(text)
+	t.Focused.MultiSelectSelector = t.Focused.MultiSelectSelector.Foreground(Accent)
+	t.Focused.SelectedOption = t.Focused.SelectedOption.Foreground(Accent)
+	t.Focused.SelectedPrefix = lipgloss.NewStyle().Foreground(ld(orangeDark, orangeVibrant)).SetString("✓ ")
+	t.Focused.UnselectedPrefix = lipgloss.NewStyle().Foreground(TextDimmed).SetString("• ")
+	t.Focused.UnselectedOption = t.Focused.UnselectedOption.Foreground(text)
+	t.Focused.FocusedButton = t.Focused.FocusedButton.
+		Foreground(ld(warmGraySuperLight, warmGrayDarkest)).
+		Background(Accent)
+	t.Focused.BlurredButton = t.Focused.BlurredButton.
+		Foreground(text).
+		Background(mutedBg)
+	t.Focused.Next = t.Focused.FocusedButton
+	t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.Foreground(Accent)
+	t.Focused.TextInput.Placeholder = t.Focused.TextInput.Placeholder.Foreground(TextDimmed)
+	t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.Foreground(Accent)
+	t.Blurred = t.Focused
+	t.Blurred.Base = t.Focused.Base.BorderStyle(lipgloss.HiddenBorder())
+	t.Blurred.Card = t.Blurred.Base
+	t.Blurred.NextIndicator = lipgloss.NewStyle()
+	t.Blurred.PrevIndicator = lipgloss.NewStyle()
+	t.Help.Ellipsis = t.Help.Ellipsis.Foreground(TextMuted)
+	t.Help.ShortKey = t.Help.ShortKey.Foreground(Accent)
+	t.Help.ShortDesc = t.Help.ShortDesc.Foreground(TextMuted)
+	t.Help.ShortSeparator = t.Help.ShortSeparator.Foreground(TextDimmed)
+	t.Help.FullKey = t.Help.FullKey.Foreground(Accent)
+	t.Help.FullDesc = t.Help.FullDesc.Foreground(TextMuted)
+	t.Help.FullSeparator = t.Help.FullSeparator.Foreground(TextDimmed)
+	t.Group.Title = t.Focused.Title
+	t.Group.Description = t.Focused.Description
+	return t
+}
+
+func SpinnerTheme(_ bool) *huhspinner.Styles {
+	return &huhspinner.Styles{
+		Spinner: lipgloss.NewStyle().Foreground(Accent),
+		Title:   lipgloss.NewStyle().Foreground(text),
+	}
+}
+
+func NewForm(groups ...*huh.Group) *huh.Form {
+	return huh.NewForm(groups...).WithTheme(huh.ThemeFunc(func(_ bool) *huh.Styles {
+		return Theme()
+	}))
+}
+
+func FangColorScheme(fld lipgloss.LightDarkFunc) fang.ColorScheme {
+	return fang.ColorScheme{
+		Base:           fld(warmGrayDark, warmGraySuperLight),
+		Title:          orange,
+		Description:    fld(warmGrayDim, warmGray),
+		Codeblock:      fld(warmGrayLight, warmGrayDarker),
+		Program:        orangeVibrant,
+		Command:        orange,
+		DimmedArgument: fld(warmGray, warmGrayDim),
+		Comment:        fld(warmGrayDim, warmGray),
+		Flag:           orangeVibrant,
+		FlagDefault:    fld(warmGrayDim, warmGray),
+		QuotedString:   fld(orangeDark, orangeSoft),
+		Argument:       fld(warmGrayDark, warmGraySuperLight),
+		Help:           fld(warmGrayDim, warmGray),
+		Dash:           fld(warmGrayDim, warmGray),
+		ErrorHeader:    [2]color.Color{warmGraySuperLight, StatusError},
+		ErrorDetails:   StatusError,
+	}
+}
+
+func ListStyles() list.Styles {
+	s := list.DefaultStyles(isDark)
+	s.Title = lipgloss.NewStyle().
+		Background(Accent).
+		Foreground(ld(warmGraySuperLight, warmGrayDarkest)).
+		Padding(0, 1)
+	s.StatusBar = s.StatusBar.Foreground(TextMuted)
+	s.ActivePaginationDot = s.ActivePaginationDot.Foreground(Accent)
+	return s
+}
+
+func ListItemStyles() list.DefaultItemStyles {
+	s := list.NewDefaultItemStyles(isDark)
+	s.NormalTitle = lipgloss.NewStyle().Foreground(text).Padding(0, 0, 0, 2)
+	s.NormalDesc = s.NormalTitle.Foreground(TextMuted)
+	s.SelectedTitle = lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder(), false, false, false, true).
+		BorderForeground(Accent).
+		Foreground(ld(orange, orangeSoft)).
+		Padding(0, 0, 0, 1)
+	s.SelectedDesc = s.SelectedTitle.Foreground(AccentAlt)
+	s.DimmedTitle = lipgloss.NewStyle().Foreground(TextDimmed).Padding(0, 0, 0, 2)
+	s.DimmedDesc = s.DimmedTitle.Foreground(textSubdued)
+	return s
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"charm.land/fang/v2"
 
 	"github.com/N1xev/spin/cmd"
+	"github.com/N1xev/spin/internal/theme"
 	"github.com/N1xev/spin/internal/version"
 )
 
@@ -21,6 +22,7 @@ func main() {
 		context.Background(),
 		cmd.RootCmd(),
 		fang.WithVersion(version.Version),
+		fang.WithColorSchemeFunc(theme.FangColorScheme),
 	)
 	if err == nil {
 		return


### PR DESCRIPTION
This PR replaces the default terminal colors throughout spin with a consistent orange and warm-gray brand palette that adapts to the user's terminal background at startup.

The colors are pre-resolved once at startup using lipgloss.LightDark plus lipgloss.HasDarkBackground instead of tracking BackgroundColorMsg at runtime. This eliminates hasDarkBg fields, style regeneration, and message handling that was previously spread across models.

What changed:

- New internal/theme/ package (160 lines) containing the full brand palette, pre-resolved semantic tokens, Huh theme, fang color scheme, list styles, and convenience helpers

- All huh.NewForm calls replaced with theme.NewForm() so prompt forms inherit the brand palette automatically

- main.go uses theme.FangColorScheme for branded --help output

- cmd/new_tui.go and cmd/hooks_tui.go use pre-resolved colors for all custom styles and view backgrounds instead of tracking isDark per model or using the compat package

- cmd/print.go and cmd/hook_output.go use theme.Accent and theme.TextDimmed for headers and body text

- Footer keybinding hints now match the same accent/muted color scheme as Huh help text

The semantic tokens (Accent, Text, TextMuted, TextDimmed, StatusError, StatusSuccess, StatusInfo) resolve adaptively at startup so the same binary looks correct on both light and dark terminals.
