### PR TITLE
Feat/bootstrap official registry

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -53,8 +53,16 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	// resolved git URL or local path.
 	if registry.IsShorthand(spec) {
 		mgr := registry.NewManager()
+		// First-run: add the official registry so the shorthand can
+		// resolve without manual setup (same behavior as `spin new`).
+		maybeBootstrapOfficial(ctx, mgr)
 		resolved, err := mgr.ResolveShorthand(ctx, spec)
 		if err != nil {
+			// Re-add hint for the removed built-in registry; for any
+			// other missing alias fall back to the generic guidance.
+			if enriched, ok := annotateShorthandError(err); ok {
+				return enriched
+			}
 			alias, _ := registry.SplitAliasID(spec)
 			return fmt.Errorf("alias %q is not a registered registry; use a full git URL instead", alias)
 		}

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/N1xev/spin/internal/log"
 	"github.com/N1xev/spin/internal/registry"
 )
 
@@ -18,7 +19,8 @@ func maybeBootstrapOfficial(ctx context.Context, mgr *registry.Manager) {
 	did, err := mgr.Bootstrap(ctx)
 	switch {
 	case err != nil:
-		printWarn("could not bootstrap official registry: %v", err)
+		log.Debug("could not bootstrap official registry", "err", err)
+		printWarn("could not set up the official registry; run this command again to retry")
 	case did:
 		printInfo("bootstrapped official registry")
 	}

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/N1xev/spin/internal/registry"
+)
+
+// maybeBootstrapOfficial registers the built-in official registry on
+// first run, when registries.json does not yet exist, and reports it
+// to the user. It is a no-op once the file is present, including when
+// the user removed the official registry on purpose. Failures (e.g.
+// no network) are surfaced as a warning and the caller proceeds; the
+// user can retry on a later command.
+func maybeBootstrapOfficial(ctx context.Context, mgr *registry.Manager) {
+	did, err := mgr.Bootstrap(ctx)
+	switch {
+	case err != nil:
+		printWarn("could not bootstrap official registry: %v", err)
+	case did:
+		printInfo("bootstrapped official registry")
+	}
+}
+
+// annotateShorthandError enriches a shorthand resolution failure with
+// a re-add hint when the missing alias is the built-in official
+// registry. The registry package only reports the structured
+// AliasNotRegisteredError; the hint is CLI presentation, so it lives
+// here. Returns the enriched error and true, or the original error
+// and false when nothing applies (nil, other failure kinds, or a
+// non-official alias with no known source).
+func annotateShorthandError(err error) (error, bool) {
+	var notRegistered registry.AliasNotRegisteredError
+	if errors.As(err, &notRegistered) && notRegistered.Alias == registry.OfficialAlias {
+		return fmt.Errorf("%w (re-add it with: spin registry add %s %s)", err, registry.OfficialAlias, registry.DefaultRegistryURL), true
+	}
+	return err, false
+}

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/N1xev/spin/internal/registry"
+)
+
+// writeMiniRegistry creates a minimal valid registry at root
+// (registry.toml + templates/<id>.toml) so a local-path source
+// passes Add's sanity checks. Mirrors the registry package's test
+// fixture for use outside that package.
+func writeMiniRegistry(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, "templates"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	regTOML := "id = \"fixture\"\nname = \"Fixture Registry\"\n"
+	if err := os.WriteFile(filepath.Join(root, "registry.toml"), []byte(regTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tplTOML := "id = \"go-api\"\nname = \"Go API\"\nsource = \"https://github.com/example/go-api.git\"\n"
+	if err := os.WriteFile(filepath.Join(root, "templates", "go-api.toml"), []byte(tplTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestMaybeBootstrapOfficial_FirstRun adds the official registry when
+// registries.json does not exist. The URL is redirected to a local
+// fixture so no network is touched.
+func TestMaybeBootstrapOfficial_FirstRun(t *testing.T) {
+	src := t.TempDir()
+	writeMiniRegistry(t, src)
+	oldURL := registry.DefaultRegistryURL
+	registry.DefaultRegistryURL = src
+	t.Cleanup(func() { registry.DefaultRegistryURL = oldURL })
+
+	mgr := registry.NewManager().SetCacheDir(t.TempDir())
+	maybeBootstrapOfficial(context.Background(), &mgr)
+	if _, ok := mgr.Get(context.Background(), "official"); !ok {
+		t.Fatal("maybeBootstrapOfficial should add the official registry on first run")
+	}
+}
+
+// TestAnnotateShorthandError verifies the CLI enrichment: the
+// official alias gets a re-add hint, while other aliases (and nil)
+// pass through unchanged.
+func TestAnnotateShorthandError(t *testing.T) {
+	enriched, ok := annotateShorthandError(registry.AliasNotRegisteredError{Alias: "official"})
+	if !ok {
+		t.Fatal("expected official alias error to be enriched")
+	}
+	if !strings.Contains(enriched.Error(), "spin registry add official") {
+		t.Errorf("expected re-add hint in enriched error; got %v", enriched)
+	}
+
+	ghost := registry.AliasNotRegisteredError{Alias: "ghost"}
+	unchanged, ok := annotateShorthandError(ghost)
+	if ok {
+		t.Errorf("non-official alias must not be enriched; got %v", unchanged)
+	}
+	if unchanged != ghost {
+		t.Errorf("error must pass through unchanged; got %v", unchanged)
+	}
+
+	if _, ok := annotateShorthandError(nil); ok {
+		t.Error("nil error must not be enriched")
+	}
+}
+
+// TestMaybeBootstrapOfficial_NoopWhenConfigured verifies the helper
+// does not touch the network or mutate registries.json when the file
+// already exists (e.g. the user removed the official registry on
+// purpose).
+func TestMaybeBootstrapOfficial_NoopWhenConfigured(t *testing.T) {
+	mgr := registry.NewManager().SetCacheDir(t.TempDir())
+	if err := os.WriteFile(mgr.RegistriesPath(), []byte(`{"registries":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	maybeBootstrapOfficial(context.Background(), &mgr)
+	if _, ok := mgr.Get(context.Background(), "official"); ok {
+		t.Fatal("maybeBootstrapOfficial must not re-add the official registry when registries.json exists")
+	}
+}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/N1xev/spin/internal/params"
+	"github.com/N1xev/spin/internal/registry"
 	srcspec "github.com/N1xev/spin/internal/spec"
 	"github.com/N1xev/spin/internal/template"
 )
@@ -111,8 +112,19 @@ func runNew(cmd *cobra.Command, args []string) error {
 		loader.PromptInvalidPinned = promptInvalidPinned
 		loader.PromptExistingDest = promptExistingDest
 	}
+
+	// If the spec is a registry shorthand and no registries are
+	// configured yet, bootstrap the official registry so the
+	// shorthand can resolve without manual setup.
+	if registry.IsShorthand(tplSpec) {
+		maybeBootstrapOfficial(cmd.Context(), registry.NewManager())
+	}
+
 	tpl, err := loader.LoadContext(cmd.Context(), tplSpec)
 	if err != nil {
+		if enriched, ok := annotateShorthandError(err); ok {
+			return enriched
+		}
 		return err
 	}
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -15,7 +15,7 @@ import (
 var searchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search registries and pinned templates",
-	Long:  "Search across templates in registered registries and pinned templates. Reads ~/.config/spin/registries/*/templates/*.toml and ~/.config/spin/pinned.json directly -- no network call. Use `spin registry add` to register a registry first.",
+	Long:  "Search across templates in registered registries and pinned templates. Reads ~/.config/spin/registries/*/templates/*.toml and ~/.config/spin/pinned.json directly -- no network call once registries are registered. The official registry is added automatically on first run; register more with `spin registry add`.",
 	Example: `  spin search "go cli"
   spin search rust --limit 5
   spin search tauri --json`,
@@ -106,6 +106,11 @@ func pinnedSearchEntries(ctx *cobra.Command, client *registry.Client, query stri
 func runSearch(cmd *cobra.Command, args []string) error {
 	query := args[0]
 	mgr := registry.NewManager()
+
+	// Bootstrap the official registry on first run so search is
+	// useful without manual setup.
+	maybeBootstrapOfficial(cmd.Context(), mgr)
+
 	idx, _, err := mgr.Build(cmd.Context())
 	if err != nil {
 		return err

--- a/docs/2.guide/4.search.md
+++ b/docs/2.guide/4.search.md
@@ -10,6 +10,10 @@ seo:
 
 A registry is a git repo or local directory with `registry.toml` and a `templates/` directory.
 
+On first run, `spin search`, `spin new <alias>/<id>`, and `spin add <alias>/<id>` automatically register the built-in official registry (`official`), so search works out of the box. Removing it later (`spin registry remove official`) is respected: it is never re-added while `registries.json` exists.
+
+To register additional registries:
+
 ```sh
 spin registry add official https://github.com/example/spin-registry.git
 ```

--- a/internal/registry/index_resolve_test.go
+++ b/internal/registry/index_resolve_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -168,6 +169,26 @@ func TestManager_ResolveShorthandUnknownAlias(t *testing.T) {
 	_, err := mgr.ResolveShorthand(context.Background(), "ghost/nope")
 	if err == nil || !strings.Contains(err.Error(), "not registered") {
 		t.Errorf("expected 'not registered' error; got %v", err)
+	}
+}
+
+func TestManager_ResolveShorthandOfficialNotRegistered(t *testing.T) {
+	mgr := newTestManager(t)
+	_, err := mgr.ResolveShorthand(context.Background(), "official/go-api")
+	if err == nil {
+		t.Fatal("expected error for unregistered official alias")
+	}
+	var notRegistered AliasNotRegisteredError
+	if !errors.As(err, &notRegistered) {
+		t.Fatalf("expected AliasNotRegisteredError; got %T: %v", err, err)
+	}
+	if notRegistered.Alias != "official" {
+		t.Errorf("alias = %q; want official", notRegistered.Alias)
+	}
+	// The registry layer must stay transport-agnostic: the failure
+	// is structured data, and CLI hints belong to the cmd layer.
+	if strings.Contains(err.Error(), "spin registry add") {
+		t.Errorf("registry error must not contain CLI hints; got %v", err)
 	}
 }
 

--- a/internal/registry/manager.go
+++ b/internal/registry/manager.go
@@ -359,8 +359,10 @@ func (m Manager) RefreshAll(ctx context.Context) ([]Registry, []string, []error)
 // Bootstrap adds the built-in official registry on first run when
 // registries.json does not yet exist. It is a no-op when the file is
 // already present, including corrupt or unreadable files: we never
-// overwrite user data. Returns true when the official registry was
-// added. Failures (e.g. network unreachable) are returned so the
+// overwrite user data. First-run registration is serialized across
+// processes via a lock file so concurrent spin invocations cannot both
+// clone the official registry. Returns true when the official registry
+// was added. Failures (e.g. network unreachable) are returned so the
 // caller can surface them; the user can retry on a later command.
 func (m Manager) Bootstrap(ctx context.Context) (bool, error) {
 	if err := ctx.Err(); err != nil {
@@ -369,10 +371,83 @@ func (m Manager) Bootstrap(ctx context.Context) (bool, error) {
 	if _, err := os.Stat(m.RegistriesPath()); err == nil || !os.IsNotExist(err) {
 		return false, nil
 	}
+	// Serialize first-run registration: claim an exclusive lock file
+	// before re-checking RegistriesPath so two concurrent spin
+	// processes cannot both register the official registry. The claim
+	// is released once Add finishes.
+	lockPath := filepath.Join(m.CacheDir, ".bootstrap.lock")
+	if err := os.MkdirAll(m.CacheDir, 0o755); err != nil {
+		return false, err
+	}
+	claimed, err := acquireBootstrapLock(lockPath)
+	if err != nil {
+		return false, err
+	}
+	if !claimed {
+		// Another process is bootstrapping; defer to it.
+		return false, nil
+	}
+	defer releaseBootstrapLock(lockPath)
+	// Double-checked locking: the winning process may have finished
+	// while we were acquiring the claim.
+	if _, err := os.Stat(m.RegistriesPath()); err == nil || !os.IsNotExist(err) {
+		return false, nil
+	}
 	if _, err := m.Add(ctx, OfficialAlias, DefaultRegistryURL, false); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+// bootstrapLockTTL is how long a .bootstrap.lock claim may stand
+// before a later process treats it as stale. The lock only guards
+// first-run registration; a process that crashes mid-bootstrap leaves
+// a claim behind, and the TTL lets a later command reclaim it instead
+// of deferring forever. It is generous so a slow clone is never
+// misread as stale.
+const bootstrapLockTTL = 2 * time.Minute
+
+// acquireBootstrapLock atomically claims lockPath with O_CREATE|O_EXCL
+// and reports whether this process won the claim. A fresh claim held
+// by another process yields false (the caller defers to it). A stale
+// claim, left by a crashed process, is moved aside via an atomic
+// rename and re-claimed, so a crash cannot block first-run bootstrap
+// permanently.
+func acquireBootstrapLock(lockPath string) (bool, error) {
+	for {
+		lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			_ = lock.Close()
+			return true, nil
+		}
+		if !os.IsExist(err) {
+			return false, err
+		}
+		info, err := os.Stat(lockPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue // released between OpenFile and Stat
+			}
+			return false, err
+		}
+		if time.Since(info.ModTime()) < bootstrapLockTTL {
+			return false, nil
+		}
+		// Stale claim: move it aside atomically, then retry. If a
+		// concurrent process wins the rename first, the retry sees its
+		// fresh claim and defers.
+		stalePath := lockPath + ".stale"
+		if err := os.Rename(lockPath, stalePath); err != nil && !os.IsNotExist(err) {
+			return false, err
+		}
+		_ = os.Remove(stalePath)
+	}
+}
+
+// releaseBootstrapLock drops a claim held by this process. Best-effort:
+// a leftover lock file is reclaimed later via the staleness TTL.
+func releaseBootstrapLock(lockPath string) {
+	_ = os.Remove(lockPath)
 }
 
 // Remove drops alias from registries.json and deletes the cache

--- a/internal/registry/manager.go
+++ b/internal/registry/manager.go
@@ -356,6 +356,25 @@ func (m Manager) RefreshAll(ctx context.Context) ([]Registry, []string, []error)
 	return updated, skipped, errs
 }
 
+// Bootstrap adds the built-in official registry on first run when
+// registries.json does not yet exist. It is a no-op when the file is
+// already present, including corrupt or unreadable files: we never
+// overwrite user data. Returns true when the official registry was
+// added. Failures (e.g. network unreachable) are returned so the
+// caller can surface them; the user can retry on a later command.
+func (m Manager) Bootstrap(ctx context.Context) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if _, err := os.Stat(m.RegistriesPath()); err == nil || !os.IsNotExist(err) {
+		return false, nil
+	}
+	if _, err := m.Add(ctx, OfficialAlias, DefaultRegistryURL, false); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // Remove drops alias from registries.json and deletes the cache
 // directory under registries/<alias>/. pinnedTemplates is the
 // current Pinned list; if any pin's Source points inside the

--- a/internal/registry/manager_test.go
+++ b/internal/registry/manager_test.go
@@ -490,3 +490,50 @@ func TestManager_BootstrapHonoursContext(t *testing.T) {
 		t.Error("Bootstrap reported did=true on cancelled context")
 	}
 }
+
+func TestManager_BootstrapDefersToLockHolder(t *testing.T) {
+	mgr := newTestManager(t)
+	if err := os.MkdirAll(mgr.CacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(mgr.CacheDir, ".bootstrap.lock")
+	if err := os.WriteFile(lockPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	did, err := mgr.Bootstrap(context.Background())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if did {
+		t.Error("Bootstrap reported did=true while another process holds the lock")
+	}
+	if _, ok := mgr.Get(context.Background(), "official"); ok {
+		t.Error("official registry must not be added while another process holds the lock")
+	}
+}
+
+func TestManager_BootstrapReclaimsStaleLock(t *testing.T) {
+	withFixtureOfficialURL(t)
+	mgr := newTestManager(t)
+	if err := os.MkdirAll(mgr.CacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(mgr.CacheDir, ".bootstrap.lock")
+	if err := os.WriteFile(lockPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stale := time.Now().Add(-bootstrapLockTTL - time.Minute)
+	if err := os.Chtimes(lockPath, stale, stale); err != nil {
+		t.Fatal(err)
+	}
+	did, err := mgr.Bootstrap(context.Background())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if !did {
+		t.Error("Bootstrap should reclaim a stale lock and register the official registry")
+	}
+	if _, ok := mgr.Get(context.Background(), "official"); !ok {
+		t.Error("official registry should be registered after reclaiming a stale lock")
+	}
+}

--- a/internal/registry/manager_test.go
+++ b/internal/registry/manager_test.go
@@ -374,3 +374,119 @@ func TestManager_AddLocalNonDirectoryErrors(t *testing.T) {
 		t.Errorf("expected 'not a directory' in error; got %v", err)
 	}
 }
+
+// withFixtureOfficialURL points DefaultRegistryURL at a local registry
+// fixture for the duration of the test, so Bootstrap never touches the
+// network. It returns the fixture path.
+func withFixtureOfficialURL(t *testing.T) string {
+	t.Helper()
+	src := t.TempDir()
+	writeRegistryFixture(t, src)
+	oldURL := DefaultRegistryURL
+	DefaultRegistryURL = src
+	t.Cleanup(func() { DefaultRegistryURL = oldURL })
+	return src
+}
+
+func TestManager_BootstrapFirstRun(t *testing.T) {
+	src := withFixtureOfficialURL(t)
+	mgr := newTestManager(t)
+
+	did, err := mgr.Bootstrap(context.Background())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if !did {
+		t.Fatal("Bootstrap reported did=false on first run")
+	}
+	reg, ok := mgr.Get(context.Background(), "official")
+	if !ok {
+		t.Fatal("official registry should be registered after first-run bootstrap")
+	}
+	if reg.Source != src {
+		t.Errorf("Source = %q, want %q", reg.Source, src)
+	}
+	if reg.Kind != KindLocal {
+		t.Errorf("Kind = %q, want local (fixture symlink)", reg.Kind)
+	}
+}
+
+func TestManager_BootstrapIdempotent(t *testing.T) {
+	withFixtureOfficialURL(t)
+	mgr := newTestManager(t)
+
+	if _, err := mgr.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("first Bootstrap: %v", err)
+	}
+	// Second call: registries.json now exists, so Bootstrap must be a
+	// no-op -- not a re-clone and not ErrAliasExists.
+	did, err := mgr.Bootstrap(context.Background())
+	if err != nil {
+		t.Fatalf("second Bootstrap: %v", err)
+	}
+	if did {
+		t.Error("Bootstrap reported did=true when registries.json already exists")
+	}
+}
+
+func TestManager_BootstrapNoopWhenConfigured(t *testing.T) {
+	mgr := newTestManager(t)
+	if err := os.WriteFile(mgr.RegistriesPath(),
+		[]byte(`{"registries":[{"alias":"custom","source":"/tmp/x","kind":"local"}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	did, err := mgr.Bootstrap(context.Background())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if did {
+		t.Error("Bootstrap reported did=true for an existing registries.json")
+	}
+	if _, ok := mgr.Get(context.Background(), "official"); ok {
+		t.Error("official registry must not be added when registries.json already exists")
+	}
+}
+
+func TestManager_BootstrapNoopOnCorruptFile(t *testing.T) {
+	mgr := newTestManager(t)
+	if err := os.WriteFile(mgr.RegistriesPath(), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	did, err := mgr.Bootstrap(context.Background())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if did {
+		t.Error("Bootstrap must not overwrite a corrupt registries.json")
+	}
+	if b, err := os.ReadFile(mgr.RegistriesPath()); err != nil || string(b) != "{not json" {
+		t.Errorf("corrupt file was modified: %q, err=%v", b, err)
+	}
+}
+
+func TestManager_BootstrapNoopOnEmptyFile(t *testing.T) {
+	mgr := newTestManager(t)
+	if err := os.WriteFile(mgr.RegistriesPath(), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	did, err := mgr.Bootstrap(context.Background())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if did {
+		t.Error("Bootstrap reported did=true for an empty registries.json")
+	}
+}
+
+func TestManager_BootstrapHonoursContext(t *testing.T) {
+	mgr := newTestManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	did, err := mgr.Bootstrap(ctx)
+	if err == nil {
+		t.Fatal("Bootstrap should return the cancellation error")
+	}
+	if did {
+		t.Error("Bootstrap reported did=true on cancelled context")
+	}
+}

--- a/internal/registry/official.go
+++ b/internal/registry/official.go
@@ -1,0 +1,10 @@
+package registry
+
+// OfficialAlias is the alias the built-in official registry is
+// registered under on first run.
+const OfficialAlias = "official"
+
+// DefaultRegistryURL is the git source of the built-in official
+// registry, bootstrapped on first run. It is a variable, not a
+// constant, so tests can redirect it to a local fixture.
+var DefaultRegistryURL = "https://github.com/spin-templates/registry"

--- a/internal/registry/resolve.go
+++ b/internal/registry/resolve.go
@@ -17,6 +17,19 @@ import (
 // be matched to a registered template.
 var ErrUnresolved = errors.New("shorthand unresolved")
 
+// AliasNotRegisteredError is returned by ResolveShorthand when the
+// alias part of a `<alias>/<id>` spec is not a registered registry.
+// It carries the alias so the CLI can enrich the failure with
+// user-facing hints; the registry package itself stays
+// transport-agnostic and never emits CLI guidance.
+type AliasNotRegisteredError struct {
+	Alias string
+}
+
+func (e AliasNotRegisteredError) Error() string {
+	return fmt.Sprintf("alias %q not registered", e.Alias)
+}
+
 // SplitAliasID splits a `<alias>/<id>` shorthand into its parts.
 func SplitAliasID(spec string) (alias, id string) {
 	i := strings.IndexByte(spec, '/')
@@ -71,7 +84,7 @@ func (m Manager) resolveShorthandDepth(ctx context.Context, spec string, depth i
 	alias, id := splitAliasID(spec)
 	reg, ok := m.Get(ctx, alias)
 	if !ok {
-		return Resolved{}, fmt.Errorf("alias %q not registered", alias)
+		return Resolved{}, AliasNotRegisteredError{Alias: alias}
 	}
 	tplPath := filepath.Join(reg.Path, "templates", id+".toml")
 	if _, err := os.Stat(tplPath); err != nil {


### PR DESCRIPTION
Auto-bootstrap the official registry on first use when no registry configuration exists. Respect explicit user removal by never recreating official once registries.json has been created. Keep registry resolution transport-agnostic by returning typed errors and enrich CLI messages only in the command layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically registers the built-in official template registry on first use of search, scaffold, or add commands.
  * Searches can use the local registry cache directly.
  * Added clearer guidance when a requested registry alias is unavailable.
* **Bug Fixes**
  * Preserves existing, corrupted, or explicitly removed registry configurations.
  * Safely handles concurrent first-run setup, cancellation, and registration failures.
* **Documentation**
  * Documented automatic official-registry setup and how to register additional registries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->